### PR TITLE
SRT-24: areas dictionary

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -18,14 +18,16 @@ services:
     ports:
       - "3000:3000"
     env_file:
-      ../sr-back/.env
-      ../sr-back/.env.local
+      - ../sr-back/.env
+      - ../sr-back/.env.local
     depends_on:
       - db
       - migrations
 
   db:
     image: postgres:15-alpine
+    # uncomment to enable db query logging
+    # command: ["postgres", "-c", "log_statement=all"]
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/sr-back/config/database.config.ts
+++ b/sr-back/config/database.config.ts
@@ -7,5 +7,6 @@ export default registerAs('database', () => ({
   database: 'shared_rentals',
   username: setEnvVar('DB_USERNAME', 'postgres'),
   password: setEnvVar('DB_PASSWORD', 'postgres'),
-  synchronize: process.env.NODE_ENV !== NODE_ENVS.production,
+  logging: process.env.NODE_ENV !== NODE_ENVS.production,
+  synchronize: false,
 }));

--- a/sr-back/migrations/1686312624644-Area.ts
+++ b/sr-back/migrations/1686312624644-Area.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Area1686312624644 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.startTransaction();
+    queryRunner.query(`
+      CREATE TYPE "area_type" AS ENUM ('city', 'country');
+    `);
+
+    queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "area" (
+        "id" SERIAL PRIMARY KEY,
+        "name" VARCHAR NOT NULL,
+        "type" "area_type" NOT NULL DEFAULT 'city',
+        "parentId" INTEGER,
+        "createdAt" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+        "updatedAt" TIMESTAMP WITH TIME ZONE DEFAULT now(),
+        FOREIGN KEY ("parentId") REFERENCES "area"("id")
+      );
+    `);
+    await queryRunner.commitTransaction();
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    queryRunner.query(`DROP TABLE IF EXISTS "area"`);
+    queryRunner.query(`DROP TYPE IF EXISTS "area_type"`);
+  }
+}

--- a/sr-back/nest-cli.json
+++ b/sr-back/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/sr-back/ormconfig.ts
+++ b/sr-back/ormconfig.ts
@@ -1,9 +1,10 @@
 import { DataSource } from 'typeorm';
 import loadConfig from './config/database.config';
 import { TestMigration1684945119367 } from './migrations/1684945119367-TestMigration';
+import { Area1686312624644 } from './migrations/1686312624644-Area';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   ...loadConfig(),
-  migrations: [TestMigration1684945119367],
+  migrations: [TestMigration1684945119367, Area1686312624644],
 });

--- a/sr-back/ormconfig.ts
+++ b/sr-back/ormconfig.ts
@@ -1,10 +1,10 @@
 import { DataSource } from 'typeorm';
 import loadConfig from './config/database.config';
-import { TestMigration1684945119367 } from './migrations/1684945119367-TestMigration';
-import { Area1686312624644 } from './migrations/1686312624644-Area';
+import * as path from 'path';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   ...loadConfig(),
-  migrations: [TestMigration1684945119367, Area1686312624644],
+  migrations: [path.join(__dirname, '/migrations/*{.ts,.js}')],
+  entities: [path.join(__dirname, '/src/**/entities/*{.ts,.js}')],
 });

--- a/sr-back/package-lock.json
+++ b/sr-back/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nanogiants/nestjs-swagger-api-exception-decorator": "^1.6.5",
         "@nestjs/cli": "^9.5.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^2.3.2",
@@ -17,6 +18,8 @@
         "@nestjs/swagger": "^6.3.0",
         "@nestjs/typeorm": "^9.0.1",
         "@types/express": "^4.17.17",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.0",
         "pg": "^8.11.0",
         "postgresql": "^0.0.1",
         "reflect-metadata": "^0.1.13",
@@ -1331,6 +1334,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/@nanogiants/nestjs-swagger-api-exception-decorator": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@nanogiants/nestjs-swagger-api-exception-decorator/-/nestjs-swagger-api-exception-decorator-1.6.5.tgz",
+      "integrity": "sha512-Ob/4mZTZqE3Do9BBi9bkvWERxaCHH3DNoaEFtmvNnNUGE2iVvcKwNzrTISfV3KMB1K1zhc1NWQUG5XAz06jsMg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.6.0 || ^8.0.0 || ^9.0.0",
+        "@nestjs/swagger": "^4.8.1 || ^5.0.0 || ^6.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.5.0.tgz",
@@ -1990,6 +2002,11 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -3062,6 +3079,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "dependencies": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6337,6 +6369,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.34",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.34.tgz",
+      "integrity": "sha512-p6g4NaQH4gK1gre32+kV14Mk6GPo2EDcPDvjbi+D2ycsPFsN4gVWNbs0itdHLZqByg6YEK8mE7OeP200I/ScTQ=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9021,6 +9058,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true
+    },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/sr-back/package.json
+++ b/sr-back/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "dependencies": {
+    "@nanogiants/nestjs-swagger-api-exception-decorator": "^1.6.5",
     "@nestjs/cli": "^9.5.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.3.2",
@@ -35,6 +36,8 @@
     "@nestjs/swagger": "^6.3.0",
     "@nestjs/typeorm": "^9.0.1",
     "@types/express": "^4.17.17",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "pg": "^8.11.0",
     "postgresql": "^0.0.1",
     "reflect-metadata": "^0.1.13",

--- a/sr-back/src/app/app.module.ts
+++ b/sr-back/src/app/app.module.ts
@@ -7,10 +7,13 @@ import appConfig from 'config/application.config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { App } from './entities/app.entity';
 import { logger } from 'src/middlewares/logger.middleware';
+import { AreaModule } from 'src/area/area.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({
+      // First found variable takes precedence, so local env first
+      envFilePath: ['.env.local', '.env'],
       load: [appConfig, dbConfig],
     }),
     TypeOrmModule.forRootAsync({
@@ -19,12 +22,12 @@ import { logger } from 'src/middlewares/logger.middleware';
       useFactory: (configService: ConfigService) => ({
         type: 'postgres',
         ...configService.get<ConfigType<typeof dbConfig>>('database'),
-        // TODO: use autowire injector
-        entities: [App],
+        autoLoadEntities: true,
         migrations: [],
       }),
     }),
     TypeOrmModule.forFeature([App]),
+    AreaModule,
   ],
   exports: [TypeOrmModule],
   controllers: [AppController],

--- a/sr-back/src/app/app.service.ts
+++ b/sr-back/src/app/app.service.ts
@@ -10,7 +10,6 @@ export class AppService {
   ) {}
 
   async getApp(): Promise<App> {
-    const a = 4;
     return await this.appRepository.findOneOrFail({ where: { id: 1 } });
   }
 

--- a/sr-back/src/area/area.controller.spec.ts
+++ b/sr-back/src/area/area.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AreaController } from './area.controller';
+import { AreaService } from './area.service';
+
+describe('AreaController', () => {
+  let controller: AreaController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AreaController],
+      providers: [AreaService],
+    }).compile();
+
+    controller = module.get<AreaController>(AreaController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/sr-back/src/area/area.controller.ts
+++ b/sr-back/src/area/area.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+} from '@nestjs/common';
+import { AreaNotFoundError, AreaService } from './area.service';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
+import { AreaTreeDTO, SingleAreaDTO } from './dto/area.dto';
+import {
+  SerializeTo,
+  SerializeWithPagingTo,
+} from 'src/common/decorators/SerializeTo';
+import { PageOptionsDTO } from 'src/common/dto/pagination.dto';
+
+@ApiTags('Areas')
+@Controller('areas')
+export class AreaController {
+  constructor(private readonly areaService: AreaService) {}
+
+  @Get('tree')
+  @SerializeWithPagingTo(AreaTreeDTO)
+  async findAll(@Query() pageOptions: PageOptionsDTO) {
+    return await this.areaService.findAllCountries({
+      withCities: true,
+      pageOptions,
+    });
+  }
+
+  @Get(':areaId')
+  @SerializeTo(SingleAreaDTO)
+  @ApiException(() => NotFoundException)
+  async findOne(@Param('areaId') id: string) {
+    try {
+      return await this.areaService.findOne(+id);
+    } catch (error) {
+      if (error instanceof AreaNotFoundError) {
+        throw new NotFoundException();
+      }
+    }
+  }
+}

--- a/sr-back/src/area/area.module.ts
+++ b/sr-back/src/area/area.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AreaService } from './area.service';
+import { AreaController } from './area.controller';
+import { Area } from './entities/area.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  controllers: [AreaController],
+  providers: [AreaService],
+  imports: [TypeOrmModule.forFeature([Area])],
+})
+export class AreaModule {}

--- a/sr-back/src/area/area.service.spec.ts
+++ b/sr-back/src/area/area.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AreaService } from './area.service';
+
+describe('AreaService', () => {
+  let service: AreaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AreaService],
+    }).compile();
+
+    service = module.get<AreaService>(AreaService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/sr-back/src/area/area.service.ts
+++ b/sr-back/src/area/area.service.ts
@@ -1,0 +1,54 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Area, AreaType } from './entities/area.entity';
+import { EntityNotFoundError, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import {
+  PageMetaDTO,
+  PageOptionsDTO,
+  ResponseWithPagination,
+} from 'src/common/dto/pagination.dto';
+
+export class AreaNotFoundError extends Error {}
+
+@Injectable()
+export class AreaService {
+  constructor(
+    @InjectRepository(Area) private readonly areaRepository: Repository<Area>,
+  ) {}
+
+  async findOne(id: number) {
+    try {
+      return await this.areaRepository.findOneOrFail({
+        where: { id },
+        relations: { parent: true, child: true },
+      });
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new AreaNotFoundError();
+      }
+
+      throw error;
+    }
+  }
+
+  async findAllCountries({
+    withCities = false,
+    pageOptions,
+  }: {
+    withCities: boolean;
+    pageOptions: PageOptionsDTO;
+  }): Promise<ResponseWithPagination<Area>> {
+    const searchOptions = { type: AreaType.COUNTRY };
+    const itemsTotal = await this.areaRepository.count({
+      where: searchOptions,
+    });
+    const data = await this.areaRepository.find({
+      relations: { child: withCities },
+      where: searchOptions,
+      take: pageOptions.take,
+      skip: pageOptions.skip,
+    });
+
+    return { data, meta: new PageMetaDTO(itemsTotal, pageOptions) };
+  }
+}

--- a/sr-back/src/area/dto/area.dto.ts
+++ b/sr-back/src/area/dto/area.dto.ts
@@ -1,0 +1,49 @@
+import { Expose } from 'class-transformer';
+import { Area, AreaType } from '../entities/area.entity';
+
+export class AreaDTO {
+  @Expose()
+  id: number;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  type: AreaType;
+
+  @Expose({ name: 'parent' })
+  country: AreaDTO | null;
+
+  @Expose({ name: 'child' })
+  cities: AreaDTO[] | null;
+
+  constructor(area: Area) {
+    console.log(area);
+    this.id = area.id;
+    this.name = area.name;
+    this.type = area.type;
+
+    if (area.parent !== null && area.parent !== undefined) {
+      this.country = new AreaDTO(area.parent);
+    }
+
+    if (area.child !== undefined && area.child.length > 0) {
+      this.cities = area.child.map((city) => new AreaDTO(city));
+    }
+  }
+}
+
+export class AreaTreeDTO extends Area {
+  static fromEntity(areas: Area[]) {
+    return areas.map((area) => new AreaDTO(area));
+  }
+}
+
+export class SingleAreaDTO {
+  @Expose()
+  area: AreaDTO;
+
+  static fromEntity(area: Area) {
+    return { area: new AreaDTO(area) };
+  }
+}

--- a/sr-back/src/area/entities/area.entity.ts
+++ b/sr-back/src/area/entities/area.entity.ts
@@ -1,0 +1,36 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum AreaType {
+  CITY = 'city',
+  COUNTRY = 'country',
+}
+
+@Entity()
+export class Area {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ enum: AreaType, type: 'enum', default: AreaType.CITY })
+  type: AreaType;
+
+  @ManyToOne(() => Area, (area) => area.child)
+  parent: Area | null;
+
+  @OneToMany(() => Area, (area) => area.parent)
+  child: Area[];
+
+  @Column({ default: 'now()', select: false })
+  createdAt: Date;
+
+  @Column({ default: 'now()', select: false })
+  updatedAt: Date;
+}

--- a/sr-back/src/common/decorators/SerializeTo.ts
+++ b/sr-back/src/common/decorators/SerializeTo.ts
@@ -1,0 +1,18 @@
+import { UseInterceptors, applyDecorators } from '@nestjs/common';
+import {
+  PagingSerializerInterceptor,
+  SerializerInterceptor,
+} from '../interceptors/serializer-interceptor/serializer.interceptor';
+import { ApiOkResponse } from '@nestjs/swagger';
+import { PageDTO } from '../dto/pagination.dto';
+
+export const SerializeTo = (dto: any) =>
+  applyDecorators(
+    UseInterceptors(new SerializerInterceptor(dto)),
+    ApiOkResponse({ type: () => dto }),
+  );
+export const SerializeWithPagingTo = (dto: any) =>
+  applyDecorators(
+    UseInterceptors(new PagingSerializerInterceptor(dto)),
+    ApiOkResponse({ type: () => PageDTO<keyof typeof dto> }),
+  );

--- a/sr-back/src/common/dto/pagination.dto.ts
+++ b/sr-back/src/common/dto/pagination.dto.ts
@@ -1,0 +1,69 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export interface ResponseWithPagination<T> {
+  data: T[];
+  meta: PageMetaDTO;
+}
+
+export class PageMetaDTO {
+  @Expose()
+  readonly page: number;
+
+  @Expose()
+  readonly take: number;
+
+  @Expose()
+  readonly pagesTotal: number;
+
+  @Expose()
+  readonly itemsTotal: number;
+
+  constructor(itemsTotal: number, pageOptions: PageOptionsDTO) {
+    this.page = pageOptions.page;
+    this.take = pageOptions.take;
+    this.pagesTotal = Math.ceil(itemsTotal / this.take);
+    this.itemsTotal = itemsTotal;
+  }
+}
+
+export class PageDTO<T> {
+  @Expose()
+  readonly data: T[];
+
+  @Expose()
+  readonly meta: PageMetaDTO;
+
+  constructor(data: T[], meta: PageMetaDTO) {
+    this.data = data;
+    this.meta = meta;
+  }
+}
+
+export class PageOptionsDTO {
+  @ApiPropertyOptional({
+    minimum: 1,
+    default: 1,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  readonly page: number = 1;
+
+  @ApiPropertyOptional({
+    minimum: 1,
+    maximum: 50,
+    default: 10,
+  })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  readonly take: number = 10;
+
+  get skip() {
+    return (this.page - 1) * this.take;
+  }
+}

--- a/sr-back/src/common/interceptors/serializer-interceptor/serializer.interceptor.ts
+++ b/sr-back/src/common/interceptors/serializer-interceptor/serializer.interceptor.ts
@@ -1,0 +1,36 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+import { PageDTO, ResponseWithPagination } from 'src/common/dto/pagination.dto';
+
+@Injectable()
+export class SerializerInterceptor implements NestInterceptor {
+  constructor(private readonly dto: any) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      map((data) => {
+        return this.dto.fromEntity(data);
+      }),
+    );
+  }
+}
+
+@Injectable()
+export class PagingSerializerInterceptor implements NestInterceptor {
+  constructor(private readonly dto: any) {}
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> {
+    return next.handle().pipe(
+      map((data: ResponseWithPagination<any>) => {
+        return new PageDTO(this.dto.fromEntity(data.data), data.meta);
+      }),
+    );
+  }
+}

--- a/sr-back/src/main.ts
+++ b/sr-back/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app/app.module';
 import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NODE_ENVS } from 'config/utility';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -25,6 +26,7 @@ async function bootstrap() {
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
   });
+  app.useGlobalPipes(new ValidationPipe({ transform: true }));
   app.enableShutdownHooks();
   await app.listen(config.get<number>('application.port', { infer: true }));
 }


### PR DESCRIPTION
**Что сделал:**
- добавил справочник по Area
- починил docker-compose
- отключи синк схемы при кажом рестарте приложения, так как он порождал таблицы, с отличающимися названиями
- включил автоматический поиск сущностей, без необходимости их явно указывать в конфиге
- добавил ValidationPipe
- добавил пагинацию и типы для нее
- добавил сериализацию в DTO
   - для корректной сериализации у самой внешней DTO должен быть метод `fromEntity(entity: T): DTO`, в котором описана сериализация

**Чего не стал делать:**
- Добавлять справочник по полу, так как его проще сделать enum'ом