### PR TITLE
SRT-35 custom error mappers

### DIFF
--- a/sr-back/src/app/modules/user/dto/create-user.dto.ts
+++ b/sr-back/src/app/modules/user/dto/create-user.dto.ts
@@ -1,23 +1,23 @@
 import { Expose } from 'class-transformer';
-import { User, UserRole } from '../entities/user.entity';
+import { UserRole } from '../entities/user.entity';
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateUserInput {
   @Expose()
+  @IsEmail()
   email: string;
 
   @Expose()
+  @IsNotEmpty()
+  @IsString()
   firstName: string;
 
   @Expose()
+  @IsNotEmpty()
+  @IsString()
   lastName: string;
 
   @Expose()
+  @IsEnum(UserRole)
   role: UserRole;
-
-  constructor(user: User) {
-    this.email = user.email;
-    this.firstName = user.firstName;
-    this.lastName = user.lastName;
-    this.role = user.role;
-  }
 }

--- a/sr-back/src/app/modules/user/dto/update-user.dto.ts
+++ b/sr-back/src/app/modules/user/dto/update-user.dto.ts
@@ -1,19 +1,6 @@
-import { Expose } from 'class-transformer';
-import { User } from '../entities/user.entity';
+import { OmitType, PartialType } from '@nestjs/swagger';
+import { CreateUserInput } from './create-user.dto';
 
-export class UpdateUserInput {
-  @Expose()
-  email: string;
-
-  @Expose()
-  firstName: string;
-
-  @Expose()
-  lastName: string;
-
-  constructor(user: User) {
-    this.email = user.email;
-    this.firstName = user.firstName;
-    this.lastName = user.lastName;
-  }
-}
+export class UpdateUserInput extends PartialType(
+  OmitType(CreateUserInput, ['role'] as const),
+) {}

--- a/sr-back/src/app/modules/user/user.controller.ts
+++ b/sr-back/src/app/modules/user/user.controller.ts
@@ -8,8 +8,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
-import { UserService } from './user.service';
+import { UserNotFoundError, UserService } from './user.service';
 import { UpdateUserInput } from './dto';
 import { PageOptionsDTO } from 'src/common/dto/pagination.dto';
 import {
@@ -17,6 +16,7 @@ import {
   SerializeWithPagingTo,
 } from 'src/common/decorators/SerializeTo';
 import { SingleUserDTO, UsersDTO } from './dto/user.dto';
+import { MapErrorToHTTP } from 'src/common/decorators/MapErrorToHTTP';
 
 @Controller()
 @ApiTags('User')
@@ -25,14 +25,14 @@ export class UserController {
 
   @Put('/user/:id')
   @SerializeTo(SingleUserDTO)
-  @ApiException(() => NotFoundException)
+  @MapErrorToHTTP(UserNotFoundError, NotFoundException)
   async updateUser(@Param('id') id: number, @Body() input: UpdateUserInput) {
     return await this.userService.updateUser(id, input);
   }
 
   @Get('/user/:id')
   @SerializeTo(SingleUserDTO)
-  @ApiException(() => NotFoundException)
+  @MapErrorToHTTP(UserNotFoundError, NotFoundException)
   async getUser(@Param('id') id: number) {
     return await this.userService.getUserById(id);
   }

--- a/sr-back/src/area/area.controller.ts
+++ b/sr-back/src/area/area.controller.ts
@@ -7,13 +7,13 @@ import {
 } from '@nestjs/common';
 import { AreaNotFoundError, AreaService } from './area.service';
 import { ApiTags } from '@nestjs/swagger';
-import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
 import { AreaTreeDTO, SingleAreaDTO } from './dto/area.dto';
 import {
   SerializeTo,
   SerializeWithPagingTo,
 } from 'src/common/decorators/SerializeTo';
 import { PageOptionsDTO } from 'src/common/dto/pagination.dto';
+import { MapErrorToHTTP } from 'src/common/decorators/MapErrorToHTTP';
 
 @ApiTags('Areas')
 @Controller('areas')
@@ -31,14 +31,8 @@ export class AreaController {
 
   @Get(':areaId')
   @SerializeTo(SingleAreaDTO)
-  @ApiException(() => NotFoundException)
+  @MapErrorToHTTP(AreaNotFoundError, NotFoundException)
   async findOne(@Param('areaId') id: string) {
-    try {
-      return await this.areaService.findOne(+id);
-    } catch (error) {
-      if (error instanceof AreaNotFoundError) {
-        throw new NotFoundException();
-      }
-    }
+    return await this.areaService.findOne(+id);
   }
 }

--- a/sr-back/src/common/decorators/MapErrorToHTTP.ts
+++ b/sr-back/src/common/decorators/MapErrorToHTTP.ts
@@ -1,0 +1,12 @@
+import { HttpException, UseFilters, applyDecorators } from '@nestjs/common';
+import { ErrorMapperFilter } from '../filters/error-mapper/error-mapper.filter';
+import { ApiException } from '@nanogiants/nestjs-swagger-api-exception-decorator';
+
+export const MapErrorToHTTP = (
+  fromError: new (...args: any[]) => Error,
+  toHTTP: new (...args: any[]) => HttpException,
+) =>
+  applyDecorators(
+    UseFilters(new ErrorMapperFilter(fromError, toHTTP)),
+    ApiException(() => toHTTP),
+  );

--- a/sr-back/src/common/filters/error-mapper/error-mapper.filter.spec.ts
+++ b/sr-back/src/common/filters/error-mapper/error-mapper.filter.spec.ts
@@ -1,0 +1,8 @@
+import { HttpException } from '@nestjs/common';
+import { ErrorMapperFilter } from './error-mapper.filter';
+
+describe('ErrorMapperFilter', () => {
+  it('should be defined', () => {
+    expect(new ErrorMapperFilter(Error, HttpException)).toBeDefined();
+  });
+});

--- a/sr-back/src/common/filters/error-mapper/error-mapper.filter.ts
+++ b/sr-back/src/common/filters/error-mapper/error-mapper.filter.ts
@@ -1,0 +1,36 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+
+import { Response } from 'express';
+
+@Catch()
+export class ErrorMapperFilter implements ExceptionFilter {
+  private readonly logger = new Logger('ErrorMapper');
+  constructor(
+    readonly ErrorCls: new (...args: any[]) => Error,
+    readonly ExceptionCls: new (...args: any[]) => HttpException,
+  ) {}
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    if (exception instanceof this.ErrorCls) {
+      const e = new this.ExceptionCls();
+
+      response.status(e.getStatus()).json(e.getResponse());
+    } else if (exception instanceof HttpException) {
+      response.status(exception.getStatus()).json(exception.getResponse());
+    } else {
+      this.logger.error(exception);
+      const e = new InternalServerErrorException();
+      response.status(e.getStatus()).json(e.getResponse());
+    }
+  }
+}

--- a/sr-back/src/middlewares/logger.middleware.ts
+++ b/sr-back/src/middlewares/logger.middleware.ts
@@ -3,6 +3,13 @@ import { NextFunction, Request, Response } from 'express';
 
 export function logger(req: Request, res: Response, next: NextFunction) {
   const logger = new Logger('Request');
+  res.on('finish', () => {
+    const logFormat = `${req.method} ${req.originalUrl} ${res.statusCode}`;
+    if (res.statusCode >= 400) {
+      logger.error(logFormat);
+    } else {
+      logger.log(logFormat);
+    }
+  });
   next();
-  logger.log(`${req.method} ${req.originalUrl} ${res.statusCode}`);
 }


### PR DESCRIPTION
Что сделано:
- отнаследовал update-user.dto от create-user.dto и добавил декораторы для валидации полей (базовые)
- поправил логирующую middleware, чтобы она логировала запросы после того как они реально завершатся, а не в момент, когда ответ поднимается по стеку вверх, так как ExceptionFilter стоит выше по кстеку вызовов и все ошибки не попадали в лог
- добавил декоратор `@MapErrorToHTTP(ErrorCls, ExceptionCls)`,  который можно использовать для задания того какая ошибка в какой Http эксепшен смапится, можно указывать несколько на одном ресурсе
- Поправил контроллер пользователей и арий, чтобы они использовали новй декоратор